### PR TITLE
V2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ O PC-Estoque é um sistema de gerenciamento de estoque desenvolvido para oferece
 
 
 ## 👥 Equipe de Desenvolvimento
+
 - Elbia Simone Buglio
 
 - Fabio Romero
@@ -15,6 +16,7 @@ O PC-Estoque é um sistema de gerenciamento de estoque desenvolvido para oferece
 
 
 ## ⚙️ Configuração do Ambiente Local
+
 - Python 3.12
 - FastAPI
 - Uvicorn
@@ -22,11 +24,13 @@ O PC-Estoque é um sistema de gerenciamento de estoque desenvolvido para oferece
 - Outras dependências listadas em requirements
 
 ## 📦 Clonando o Repositório
+
 git clone https://github.com/projeto-carreira-luizalabs-2025/pc-estoque/tree/v1
 
 cd pc-estoque
 
 ## 📑 Configuração no Linux 🐧
+
 Crie o ambiente virtual:
 make build-venv
 
@@ -39,7 +43,9 @@ make requirements-dev
 ⚠️ A partir deste ponto, todos os comandos deverão ser executados dentro do ambiente virtual ativado.
 
 ## 📑 Configuração no Windows 🪟
-**📌 1️⃣ Instalar o make via MSYS2 (se ainda não instalado)**
+
+### **📌 1️⃣ Instalar o make via MSYS2 (se ainda não instalado)**
+
 - Baixe o instalador do MSYS2:
   
 👉 https://www.msys2.org/
@@ -49,7 +55,7 @@ pacman -Syu
 pacman -S make
 - Depois de instalado, você poderá usar o make no terminal MSYS2 ou adicionar o caminho do make.exe no PATH para uso em outros terminais.
 
-**📌 2️⃣ Criar o ambiente virtual:**
+### **📌 2️⃣ Criar o ambiente virtual:**
 
 python -m venv venv
 
@@ -73,6 +79,7 @@ python --version
 ⚠️ Certifique-se de ativar o ambiente virtual antes de executar qualquer comando relacionado ao projeto.
 
 ## ▶️ Execução
+
 **1️⃣ Configurar as variáveis de ambiente**
 
 Copie o arquivo de variáveis de desenvolvimento:
@@ -90,11 +97,12 @@ make run-dev
 
 ou, se preferir executar manualmente:
 
-uvicorn app01:app --reload
+uvicorn app.api_main:app --reload
 
 ## 📖 Acesse a documentação interativa da API:
-- Swagger UI: http://localhost:8000/docs
-- ReDoc: http://localhost:8000/redoc
+
+- Swagger UI: http://localhost:8000/api/docs
+- ReDoc: http://localhost:8000/api/redoc
 
 ## 📬 Contribuições e Atualizações  
 

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,8 +1,12 @@
 from fastapi import APIRouter
 
 from app.api.v1 import router_estoque
+from app.api.v2 import routes_estoque as router_estoque_v2
+
+
 
 routes = APIRouter()
 
 routes.include_router(router_estoque)                                         
 
+routes.include_router(router_estoque_v2.router)

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.v1 import router_estoque
-from app.api.v2 import routes_estoque as router_estoque_v2
+from app.api.v2 import router_estoque_v2
 
 
 
@@ -9,4 +9,4 @@ routes = APIRouter()
 
 routes.include_router(router_estoque)                                         
 
-routes.include_router(router_estoque_v2.router)
+routes.include_router(router_estoque_v2)

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter
 from app.settings import api_settings
 
 
-router_estoque = APIRouter(prefix="/seller/v1", tags=["API"])
+router_estoque = APIRouter(prefix="/seller/v1", tags=["Estoque V1"])
 
 
 def load_routes(router_estoque: APIRouter):

--- a/app/api/v1/routers/__init__.py
+++ b/app/api/v1/routers/__init__.py
@@ -1,3 +1,1 @@
 SOMETHING_PREFIX = "/somethings"
-
-ESTOQUE_PREFIX = "/estoque"

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -3,12 +3,12 @@ from fastapi import APIRouter
 from app.settings import api_settings
 
 
-router_estoque = APIRouter(prefix="/seller/v1", tags=["API"])
+router_estoque = APIRouter(prefix="/seller/v2", tags=["API"])
 
 
 def load_routes(router_estoque: APIRouter):
     if api_settings.enable_estoque_resources:
-        from app.api.v1.routers.estoque_router import router
+        from app.api.v2.routers.estoque_router import router
 
         router_estoque.include_router(router)
 

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,16 +1,18 @@
 from fastapi import APIRouter
 
+from app.api.v2.routers.estoque_router import router as estoque_router_v2
+
 from app.settings import api_settings
 
 
-router_estoque = APIRouter(prefix="/seller/v2", tags=["API"])
+router_estoque_v2 = APIRouter(prefix="/seller/v2", tags=["Estoque V2"])
 
 
 def load_routes(router_estoque: APIRouter):
     if api_settings.enable_estoque_resources:
         from app.api.v2.routers.estoque_router import router
 
-        router_estoque.include_router(router)
+        router_estoque.include_router(estoque_router_v2)
 
 
-load_routes(router_estoque)
+load_routes(router_estoque_v2)

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+
+from app.settings import api_settings
+
+
+router_estoque = APIRouter(prefix="/seller/v1", tags=["API"])
+
+
+def load_routes(router_estoque: APIRouter):
+    if api_settings.enable_estoque_resources:
+        from app.api.v1.routers.estoque_router import router
+
+        router_estoque.include_router(router)
+
+
+load_routes(router_estoque)

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -10,7 +10,6 @@ router_estoque_v2 = APIRouter(prefix="/seller/v2", tags=["Estoque V2"])
 
 def load_routes(router_estoque: APIRouter):
     if api_settings.enable_estoque_resources:
-        from app.api.v2.routers.estoque_router import router
 
         router_estoque.include_router(estoque_router_v2)
 

--- a/app/api/v2/routers/__init__.py
+++ b/app/api/v2/routers/__init__.py
@@ -1,0 +1,3 @@
+SOMETHING_PREFIX = "/somethings"
+
+ESTOQUE_PREFIX = "/estoque"

--- a/app/api/v2/routers/estoque_router.py
+++ b/app/api/v2/routers/estoque_router.py
@@ -1,0 +1,78 @@
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, Header, status
+
+from app.api.common.schemas import ListResponse, Paginator, get_request_pagination
+from app.api.v1.schemas.estoque_schema import EstoqueCreate, EstoqueResponse, EstoqueUpdate
+from app.services.estoque_service import EstoqueServices
+from app.container import Container
+
+
+router = APIRouter(prefix="/seller/v2/estoque", tags=["Estoque V2"])
+
+@router.get(
+    "",
+    response_model=ListResponse[EstoqueResponse],
+    status_code=status.HTTP_200_OK,
+)
+@inject
+async def list_estoque_v2(
+    x_seller_id: str = Header(..., alias="x-seller-id"),
+    paginator: Paginator = Depends(get_request_pagination),
+    estoque_service: EstoqueServices = Depends(Provide[Container.estoque_service]),
+):
+    result = await estoque_service.list(paginator=paginator, filters={"seller_id": x_seller_id})
+    return paginator.paginate(results=result)
+
+@router.get(
+    "/{sku}",
+    response_model=EstoqueResponse,
+    status_code=status.HTTP_200_OK,
+)
+@inject
+async def list_estoque_by_seller_and_sku_v2(
+    sku: str,
+    x_seller_id: str = Header(..., alias="x-seller-id"),
+    estoque_service: EstoqueServices = Depends(Provide[Container.estoque_service]),
+):
+    return await estoque_service.find_by_seller_id_and_sku(x_seller_id, sku)
+
+@router.post(
+    "",
+    response_model=EstoqueResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+@inject
+async def create_estoque_v2(
+    estoque: EstoqueCreate,
+    x_seller_id: str = Header(..., alias="x-seller-id"),
+    estoque_service: EstoqueServices = Depends(Provide[Container.estoque_service]),
+):
+    estoque_model = estoque.to_model()
+    estoque_model.seller_id = x_seller_id  # sobrescreve com valor do cabeçalho
+    return await estoque_service.create(estoque_model)
+
+@router.patch(
+    "/{sku}",
+    response_model=EstoqueResponse,
+    status_code=status.HTTP_200_OK,
+)
+@inject 
+async def update_estoque_by_seller_and_sku_v2(
+    sku: str,
+    estoque_update: EstoqueUpdate,
+    x_seller_id: str = Header(..., alias="x-seller-id"),
+    estoque_service: EstoqueServices = Depends(Provide[Container.estoque_service]),
+):
+    return await estoque_service.update(x_seller_id, sku, estoque_update)
+
+@router.delete(
+    "/{sku}",
+    status_code=status.HTTP_200_OK,
+)
+@inject
+async def delete_estoque_by_seller_and_sku_v2(
+    sku: str,
+    x_seller_id: str = Header(..., alias="x-seller-id"),
+    estoque_service: EstoqueServices = Depends(Provide[Container.estoque_service]),
+):
+    return await estoque_service.delete(x_seller_id, sku)

--- a/app/api/v2/routers/estoque_router.py
+++ b/app/api/v2/routers/estoque_router.py
@@ -2,16 +2,16 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Header, status
 
 from app.api.common.schemas import ListResponse, Paginator, get_request_pagination
-from app.api.v1.schemas.estoque_schema import EstoqueCreate, EstoqueResponse, EstoqueUpdate
+from app.api.v2.schemas.estoque_schema import EstoqueCreateV2, EstoqueResponseV2, EstoqueUpdateV2
 from app.services.estoque_service import EstoqueServices
 from app.container import Container
 
 
-router = APIRouter(prefix="/seller/v2/estoque", tags=["Estoque V2"])
+router = APIRouter(prefix="/estoque", tags=["Estoque V2"])
 
 @router.get(
     "",
-    response_model=ListResponse[EstoqueResponse],
+    response_model=ListResponse[EstoqueResponseV2],
     status_code=status.HTTP_200_OK,
 )
 @inject
@@ -25,7 +25,7 @@ async def list_estoque_v2(
 
 @router.get(
     "/{sku}",
-    response_model=EstoqueResponse,
+    response_model=EstoqueResponseV2,
     status_code=status.HTTP_200_OK,
 )
 @inject
@@ -38,12 +38,12 @@ async def list_estoque_by_seller_and_sku_v2(
 
 @router.post(
     "",
-    response_model=EstoqueResponse,
+    response_model=EstoqueResponseV2,
     status_code=status.HTTP_201_CREATED,
 )
 @inject
 async def create_estoque_v2(
-    estoque: EstoqueCreate,
+    estoque: EstoqueCreateV2,
     x_seller_id: str = Header(..., alias="x-seller-id"),
     estoque_service: EstoqueServices = Depends(Provide[Container.estoque_service]),
 ):
@@ -53,13 +53,13 @@ async def create_estoque_v2(
 
 @router.patch(
     "/{sku}",
-    response_model=EstoqueResponse,
+    response_model=EstoqueResponseV2,
     status_code=status.HTTP_200_OK,
 )
 @inject 
 async def update_estoque_by_seller_and_sku_v2(
     sku: str,
-    estoque_update: EstoqueUpdate,
+    estoque_update: EstoqueUpdateV2,
     x_seller_id: str = Header(..., alias="x-seller-id"),
     estoque_service: EstoqueServices = Depends(Provide[Container.estoque_service]),
 ):

--- a/app/api/v2/schemas/base.py
+++ b/app/api/v2/schemas/base.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from typing import TypeAlias
+from uuid import UUID as UuidType
+
+from pydantic import BaseModel, Field
+
+ModelSchema: TypeAlias = BaseModel
+
+
+# Pydantic Mixins
+class UuidMixinSchema(BaseModel):
+    id: UuidType | None = Field(None, description="Identificador do objeto")
+
+
+class TimestampMixinSchema(BaseModel):
+    created_at: datetime | None = Field(None, description="Data e hora da criação")
+    updated_at: datetime | None = Field(None, description="Data e hora da atualização")

--- a/app/api/v2/schemas/estoque_schema.py
+++ b/app/api/v2/schemas/estoque_schema.py
@@ -1,0 +1,25 @@
+from pydantic import Field
+from app.api.common.schemas import ResponseEntity, SchemaType
+from app.models.estoque_model import Estoque
+
+
+class EstoqueSchema(SchemaType):
+    seller_id: str = Field(..., min_length=1, description="seller_id não pode ser vazio")
+    sku: str = Field(..., min_length=1, description="sku não pode ser vazio")
+    quantidade: int = Field(..., ge=0, description="quantidade deve ser maior ou igual a zero")
+
+
+class EstoqueResponse(EstoqueSchema, ResponseEntity):
+    """Resposta adicionando"""
+
+
+class EstoqueCreate(EstoqueSchema):
+    """Schema para criação de Estoques"""
+
+    def to_model(self) -> Estoque:
+        return Estoque(**self.model_dump())
+
+
+class EstoqueUpdate(SchemaType):
+    """Permite apenas a atualização da quantidade"""
+    quantidade: int = Field(..., ge=0, description="Quantidade deve ser maior ou igual a zero")

--- a/app/api/v2/schemas/estoque_schema.py
+++ b/app/api/v2/schemas/estoque_schema.py
@@ -9,17 +9,17 @@ class EstoqueSchema(SchemaType):
     quantidade: int = Field(..., ge=0, description="quantidade deve ser maior ou igual a zero")
 
 
-class EstoqueResponse(EstoqueSchema, ResponseEntity):
+class EstoqueResponseV2(EstoqueSchema, ResponseEntity):
     """Resposta adicionando"""
 
 
-class EstoqueCreate(EstoqueSchema):
+class EstoqueCreateV2(EstoqueSchema):
     """Schema para criação de Estoques"""
 
     def to_model(self) -> Estoque:
         return Estoque(**self.model_dump())
 
 
-class EstoqueUpdate(SchemaType):
+class EstoqueUpdateV2(SchemaType):
     """Permite apenas a atualização da quantidade"""
     quantidade: int = Field(..., ge=0, description="Quantidade deve ser maior ou igual a zero")

--- a/app/api_main.py
+++ b/app/api_main.py
@@ -26,6 +26,7 @@ def init() -> FastAPI:
     # Autowiring
     container.wire(modules=["app.api.common.routers.health_check_routers"])
     container.wire(modules=["app.api.v1.routers.estoque_router"])
+    container.wire(modules=["app.api.v2.routers.estoque_router"])
 
     # Outros middlewares podem ser adicionados aqui se necessário
 

--- a/app/services/estoque_service.py
+++ b/app/services/estoque_service.py
@@ -1,7 +1,6 @@
 from uuid import UUID
 
 from app.api.common.schemas.pagination import Paginator
-from app.api.v1.schemas.estoque_schema import EstoqueUpdate 
 from ..models.estoque_model import Estoque
 from ..repositories.estoque_repository import EstoqueRepository
 from .base import CrudService
@@ -25,7 +24,8 @@ class EstoqueServices(CrudService[Estoque, UUID]):
         return await self.repository.create(estoque)
 
     async def update(self, seller_id: str, sku: str, estoque_update) -> Estoque:
-        
+        from app.api.v1.schemas.estoque_schema import EstoqueUpdate 
+
 
         """
         Atualiza um estoque existente.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 -r requirements/base.txt
-uuid7


### PR DESCRIPTION
Alteração seller_id no cabeçalho

✅ Objetivo da Mudança
Ajustar o padrão de requisição da API para que o seller_id, anteriormente passado como parte da URL, seja enviado através do cabeçalho da requisição. Visando padronizar e tornar a API mais segura, além de facilitar futuros controles de acesso e auditoria.

 **Exemplo de estrutura de dados no Estoque:**
```js
{
    "seller_id": "LuizaLabs",
    "sku": "PROD01",
    "quantidade": 1      // Unidade disponível no estoque
}
```
Alterações:

POST: 

Versão atual (V1):

POST /seller/v1/estoque/
{
    "seller_id": "LuizaLabs",
    "sku": "PROD01",
    "quantidade": 1
}

Nova versão (V2)
 
POST /seller/v2/estoque/
Headers:
x-seller-id: LuizaLabs
Body:
{
    "sku": "PROD01",
    "quantidade": 1
}

GET:

Versão atual (V1):

GET/seller/v1/estoque/LuizaLabs

Nova Versão (v2)

GET /seller/v2/estoque
Headers:
x-seller-id: LuizaLabs

PUT:

Versão atual (V1):

PUT /seller/v1/estoque/LuizaLabs/PROD01
Body:
{
  "quantidade": 1
}

Nova versão (V2)

PUT /seller/v2/estoque/PROD01
Headers:
x-seller-id: LuizaLabs
Body:
{
  "quantidade": 1
}

DELETE

Versão atual (V1):

DELETE /seller/v1/estoque/LuizaLabs/PROD01


Nova versão (V2)

DELETE /seller/v2/estoque/PROD01
Headers:
x-seller-id: LuizaLabs

⚠️ Pontos de Atenção
Todas as validações e buscas que usavam seller_id devem ser adaptadas para buscar o valor via cabeçalho.
Documentar os novos exemplos no README.
É recomendada a coexistência temporária entre v1 e v2 até a migração total.